### PR TITLE
Update blender_simplify to Blender 2.8 API

### DIFF
--- a/blender_simplify.py
+++ b/blender_simplify.py
@@ -51,7 +51,7 @@ print('\n Clearing blender scene (default garbage...)')
 bpy.ops.object.select_all(action='DESELECT')
 
 # selection
-bpy.data.objects['Camera'].select = True
+bpy.data.objects['Camera'].select_set(True)
 
 # remove it
 bpy.ops.object.delete() 
@@ -60,9 +60,9 @@ bpy.ops.object.delete()
 # select objects by type
 for o in bpy.data.objects:
     if o.type == 'MESH':
-        o.select = True
+        o.select_set(True)
     else:
-        o.select = False
+        o.select_set(False)
 
 # call the operator once
 bpy.ops.object.delete()


### PR DESCRIPTION
Using the current code on Blender 2.8 yields the following error:

```
bpy.data.objects['Camera'].select = True
AttributeError: 'Object' object has no attribute 'select'
```

According to [API changes](https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API/Scene_and_Object_API) in Blender 2.8:

_In 2.7x, you could directly (de)select an Object from its select property. This has been removed in 2.8x, in favor of some get/set functions._

Therefore, we need to change this piece of code to allow for direct usage on Blender 2.8, which is now the default for installation.